### PR TITLE
Use ComposerState fields to hold answer data

### DIFF
--- a/js/src/forum/addComposerFields.js
+++ b/js/src/forum/addComposerFields.js
@@ -4,8 +4,6 @@ import DiscussionComposer from 'flarum/common/components/DiscussionComposer';
 import FieldsEditor from './components/FieldsEditor';
 
 export default function () {
-    DiscussionComposer.prototype.masonAnswers = [];
-
     extend(DiscussionComposer.prototype, 'headerItems', function (items) {
         if (!app.forum.canFillMasonFields()) {
             return;
@@ -14,9 +12,9 @@ export default function () {
         items.add(
             'mason-fields',
             <FieldsEditor
-                answers={this.masonAnswers}
+                answers={this.composer.fields.masonAnswers || []}
                 onchange={(answers) => {
-                    this.masonAnswers = answers;
+                    this.composer.fields.masonAnswers = answers;
                 }}
                 ontagchange={(tags) => {
                     this.composer.fields.tags = tags;
@@ -26,11 +24,11 @@ export default function () {
     });
 
     extend(DiscussionComposer.prototype, 'data', function (data) {
-        if (!app.forum.canFillMasonFields()) {
+        if (!app.forum.canFillMasonFields() || !this.composer.fields.masonAnswers) {
             return;
         }
 
         data.relationships = data.relationships || {};
-        data.relationships.masonAnswers = this.masonAnswers;
+        data.relationships.masonAnswers = this.composer.fields.masonAnswers;
     });
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Switches from a local variable on the `DiscussionComposer` to the official Flarum fields API on `ComposerState`.

This enables other extensions to read and modify the data, and most importantly for me this allows destroying and re-creating the Composer component without loosing the data which I need for another of my extensions.

**Reviewers should focus on:**
Any backward compatibility necessary? Probably not.

I don't know of any extension would touch this value.

**Screenshot**
No visual change

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
